### PR TITLE
Adds correct semantics to basic-list-box

### DIFF
--- a/basic-list-box.html
+++ b/basic-list-box.html
@@ -138,8 +138,22 @@ Polymer({
     if ( this.getAttribute( "generic" ) == null ) {
       this.generic = true;
     }
-    if ( this.getAttribute( "aria-role" ) == null ) {
-      this.setAttribute( "aria-role", "listbox" );
+    if ( this.getAttribute( "role" ) == null ) {
+      this.setAttribute( "role", "listbox" );
+    }
+    var componentId = '';
+    if(this.getAttribute( "id" )) {
+      componentId = this.getAttribute( "id" );
+    }
+
+    this.childBaseId = componentId + "option";
+
+    if( this.children.length) {
+      var children = this.children;
+      for (var i = 0; i < children.length; i++) {
+        children[i].setAttribute("role", "option");
+        children[i].setAttribute( "id", this.childBaseId + i);
+      }
     }
   },
 
@@ -156,6 +170,17 @@ Polymer({
     if ( this.selectedItem ) {
       this._scrollElementIntoView( this.selectedItem );
     }
+    this.setActiveDescendant();
+  },
+
+  /**
+   * Update active child for accessibility.
+   *
+   * @method setActiveDescendant
+   */
+  setActiveDescendant: function(){
+    var activeChildId = this.childBaseId + this.selected;
+    this.setAttribute( "aria-activedescendant",  activeChildId );
   },
 
   /**

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ basic-framed-content {
 
 <body unresolved>
 <basic-framed-content>
-<basic-list-box id="list" tabIndex="0">
+<basic-list-box id="list" tabIndex="0" aria-label="Fruits">
   <div>Acai</div>
   <div>Acerola</div>
   <div>Apple</div>


### PR DESCRIPTION
To be accessible, the basic-list-box and its child elements needs correct roles, states and properties. The technique in this PR uses `aria-activedescendant` to communicate which child item is selected. Further semantics have been added to `basic-selector`, PR here: https://github.com/basic-web-components/basic-selector/pull/1
